### PR TITLE
Build with R v4.0

### DIFF
--- a/conda_pkg/cacao/meta.yaml
+++ b/conda_pkg/cacao/meta.yaml
@@ -16,18 +16,17 @@ build:
 
 requirements:
   build:
+    - python =3.7
+    - r-base =4.0.2
     - curl
     - unzip
-    - r-base
-    - r-devtools
     - tar
-    - python
     - toml
     - pip
     - setuptools
     #
     ### Need R modules to install the cacao R package during build-time
-    - libgfortran-ng  # to fix -libgfortran error, thanks @pdiakumis
+    - r-devtools
     - r-rmarkdown
     - r-configr
     - r-dplyr
@@ -42,9 +41,10 @@ requirements:
     - r-rlogging
     - r-crosstalk
     - r-forcats
-    - r-openssl >=1.1
 
   run:
+    - python =3.7
+    - r-base =4.0.2
     - bedtools
     - htslib
     - numpy
@@ -57,7 +57,6 @@ requirements:
     - mosdepth
     - tabix
     - pandoc
-    - libgfortran-ng  # to fix -libgfortran error, thanks @pdiakumis
     - r-rmarkdown
     - r-configr
     - r-dplyr
@@ -72,7 +71,6 @@ requirements:
     - r-rlogging
     - r-crosstalk
     - r-forcats
-    - r-openssl >=1.1
 
 test:
   commands:

--- a/conda_pkg/cacao/meta.yaml
+++ b/conda_pkg/cacao/meta.yaml
@@ -16,8 +16,8 @@ build:
 
 requirements:
   build:
-    - python =3.7
-    - r-base =4.0.2
+    - python
+    - r-base
     - curl
     - unzip
     - tar
@@ -43,8 +43,6 @@ requirements:
     - r-forcats
 
   run:
-    - python =3.7
-    - r-base =4.0.2
     - bedtools
     - htslib
     - numpy


### PR DESCRIPTION
Basically only diff with your meta.yaml is that I've dropped `libgfortran-ng` and `r-openssl`.
Used `conda build --R 4.0 cacao`. This keeps the tar.bz2 name without py/r versions as discussed.
I've uploaded to https://anaconda.org/pcgr/cacao/files
